### PR TITLE
Handle multiline records that begin with leading tabs

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -91,7 +91,7 @@ function parse_component(component, next_state) {
 // The second argument is an optional calendar object containing VTIMEZONE
 // data to aid in the correct conversion of dates
 exports.parse_calendar = function(data, timezone) {
-    data = data.split(/\r?\n/);
+    data = data.split(/\r?\n(?!\t)/);
     var calendar = new iCalendar(true);
     if(timezone) {
         if(typeof timezone === 'string')


### PR DESCRIPTION
Using an example Outlook .ics, node-icalendar choked on multiple lines that had leading tabs.
