### PR TITLE
Add support for all day events.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -49,7 +49,7 @@ var properties = exports.properties = {
     COMPLETED: { type: 'DATE-TIME' },
     DTEND:     { type: 'DATE-TIME' },
     DUE:       { type: 'DATE-TIME' },
-    DTSTART:   { type: 'DATE-TIME' },
+    DTSTART:   { type: 'DATE-TIME', altType: 'DATE' },
     DURATION:  { type: 'DURATION' },
     FREEBUSY:  { type: 'PERIOD' },
     TRANSP:    { type: 'TEXT' },
@@ -130,10 +130,10 @@ CalendarObject.prototype.addProperties = function(props) {
     props.forEach(this.addProperty.bind(this));
 }
 
-CalendarObject.prototype.addProperty = function(prop, value, parameters) {
+CalendarObject.prototype.addProperty = function(prop, value, parameters, useAltType) {
     if(!(prop instanceof CalendarProperty)) {
         if(value === undefined) return;
-        prop = new CalendarProperty(prop, value, parameters);
+        prop = new CalendarProperty(prop, value, parameters, useAltType);
     }
     else
         prop = prop.clone();
@@ -240,10 +240,10 @@ CalendarObject.prototype.format = function() {
 
 
 
-var CalendarProperty = exports.CalendarProperty = function(name, value, parameters) {
+var CalendarProperty = exports.CalendarProperty = function(name, value, parameters, useAltType) {
     var propdef = properties[name];
 
-    this.type = propdef && propdef.type ? propdef.type : 'TEXT';
+    this.type = propdef && propdef[useAltType ? 'altType' : 'type'] ? propdef[useAltType ? 'altType' : 'type'] : 'TEXT';
     this.name = name;
     this.value = value;
     this.parameters = parameters || {};

--- a/lib/event.js
+++ b/lib/event.js
@@ -59,11 +59,14 @@ VEvent.prototype.setDescription = function(desc) {
 }
 
 VEvent.prototype.setDate = function(start, end) {
-    this.addProperty('DTSTART', start);
-    if(end instanceof Date)
-        this.addProperty('DTEND', end);
-    else
-        this.addProperty('DURATION', end);
+    var allDay = (typeof end === 'undefined');
+    this.addProperty('DTSTART', start, {}, allDay); 
+    if(!allDay) {
+        if(end instanceof Date)
+            this.addProperty('DTEND', end);
+        else
+            this.addProperty('DURATION', end);
+    }
 }
 
 VEvent.prototype.rrule = function() {


### PR DESCRIPTION
First off, thanks for a great node module!

The project that I'm working on needed support for all day events.  In an effort to get that working, I added support for an altType in CalendarProperty.  This way we can use two different types for DTSTART (DATE-TIME and DATE).  I then changed setDate() so that, when it is called with an undefined end parameter, it adds the DTSTART property using its altType (DATE) and does not add a DTEND or DURATION property.  This makes the event appear as an all day event in my tests (using Apple's calendar app).  This method of creating an all day event is mentioned in the RFC in [section 3.6.1, page 53](http://tools.ietf.org/html/rfc5545#section-3.6.1).

Hopefully this fits in with the direction you're going with the module, but let me know if it doesn't or if there's something you think should be implemented differently.
