### PR TITLE
Added handling of Date instances to the DURATION: allows absolute time settings of TRIGGER

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -116,6 +116,12 @@ var _types = {
     },
     'DURATION': {
         format: function(value) {
+            // Duration values from JS should be an integer number of seconds or a Date
+            if(value instanceof Date){
+                // use the existing DATE-TIME format
+		        return _types['DATE-TIME'].format(value, {'VALUE': 'DATE-TIME'});
+	        }
+            
             // Duration values from JS should be an integer number of seconds
             var neg = value < 0;
             if(neg) value *= -1;


### PR DESCRIPTION
From page 74 of RFC 5545 (http://tools.ietf.org/html/rfc5545#page-74):

The "TRIGGER" property specifies when the alarm will be triggered.
      The "TRIGGER" property specifies a duration prior to the start of
      an event or a to-do.  The "TRIGGER" edge may be explicitly set to
      be relative to the "START" or "END" of the event or to-do with the
      "RELATED" parameter of the "TRIGGER" property.  The "TRIGGER"
      property value type can alternatively be set to an absolute
      calendar date with UTC time.

Was trying to get Google to accept my ICS files with the trigger set and realized they do absolute time but the node-icalendar package doesn't. Small change to check if the DURATION was set to a Date object, and if so just reuse the existing DATE-TIME format.
