### PR TITLE
Reference `until` when calculating next occurrence

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -168,7 +168,7 @@ RRule.prototype.next = function(after) {
     // Events don't occur before the start or after the end...
     if(!after || after < this.start)
         after = new Date(this.start.valueOf() - 1);
-    if(this.end && after > this.end) return null;
+    if(this.until && after > this.until) return null;
 
     var freq = FREQ[this.rule.FREQ];
     if(!freq)
@@ -194,7 +194,7 @@ RRule.prototype.next = function(after) {
     }
 
     // Date is off the end of the spectrum...
-    if(this.end && next > this.end)
+    if(this.until && next > this.until)
         return null;
 
     if(this.rule.COUNT && this.count_end !== null) {

--- a/spec/rrule-spec.js
+++ b/spec/rrule-spec.js
@@ -58,6 +58,46 @@ describe("RRule", function() {
                 ]);
     });
 
+    it("finds recurrences in a specific timeframe, ignoring `dtend`", function() {
+        var rrule = new RRule(
+          'FREQ=MONTHLY;BYDAY=3MO',
+          new Date(2013,2,18,9),
+          new Date(2013,2,18,10)
+       );
+
+        expect(rrule.nextOccurences(new Date(2013,9,1), new Date(2013,11,1)))
+                .toEqual([
+                    new Date(2013,9,21,9),
+                    new Date(2013,10,18,9)
+                ]);
+    });
+
+    it("finds recurrences in a specific timeframe, honoring `until`", function() {
+        var rrule = new RRule(
+          'FREQ=MONTHLY;BYDAY=3MO;UNTIL=20131101',
+          new Date(2013,2,18,9),
+          new Date(2013,2,18,10)
+       );
+
+        expect(rrule.nextOccurences(new Date(2013,9,1), new Date(2013,11,1)))
+                .toEqual([
+                    new Date(2013,9,21,9),
+                ]);
+    });
+
+    it("finds recurrences in a specific timeframe, honoring `until` (inclusive)", function() {
+        var rrule = new RRule(
+          'FREQ=MONTHLY;BYDAY=3MO;UNTIL=20130318',
+          new Date(2013,2,18),
+          new Date(2013,2,18)
+       );
+
+        expect(rrule.nextOccurences(new Date(2013,2,1), new Date(2013,2,20)))
+                .toEqual([
+                    new Date(2013,2,18),
+                ]);
+    });
+
     it("respects EXDATE date_only parts", function() {
         var rrule = new RRule('FREQ=MONTHLY', {
             DTSTART: new Date(2011,0,1),


### PR DESCRIPTION
According to RFC 5545:

> The UNTIL rule part defines a DATE or DATE-TIME value that bounds the
> recurrence rule in an inclusive manner.  If the value specified by
> UNTIL is synchronized with the specified recurrence, this DATE or
> DATE-TIME becomes the last instance of the recurrence.

[1] http://tools.ietf.org/html/rfc5545
