### PR TITLE
fix timezone issues in rrule

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -183,8 +183,8 @@ RRule.prototype.next = function(after) {
         for(var i=0; i < this.exceptions.length; i++) {
             var exdate = this.exceptions[i];
             if((exdate.valueOf() == nextInLocal.valueOf())
-                    || (exdate.date_only && y(exdate) == y(nextInLocal)
-                    && m(exdate) == m(nextInLocal) && d(exdate) == d(nextInLocal))) {
+                    || (exdate.date_only && y(to_utc_date(exdate)) == y(nextInLocal)
+                    && m(to_utc_date(exdate)) == m(nextInLocal) && d(to_utc_date(exdate)) == d(nextInLocal))) {
                 after = next;
                 continue NextOccurs;
             }
@@ -204,11 +204,11 @@ RRule.prototype.next = function(after) {
             this.count_end = this.nextOccurences(this.rule.COUNT).pop();
         }
 
-        if(next > this.count_end)
+        if(next > to_utc_date(this.count_end))
             return null;
     }
 
-    if(this.rule.UNTIL && next > this.rule.UNTIL)
+    if(this.rule.UNTIL && next > to_utc_date(this.rule.UNTIL))
         return null;
 
     return from_utc_date(next);


### PR DESCRIPTION
This commit fixes the timezone dependency of the test suite. Now the tests complete even when the system timezone is not UTC.

fixes #15
