### PR TITLE
Add fix and test for alternate datatypes

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -239,5 +239,9 @@ var parse_value = exports.parse_value = function(type, value, parameters, calend
     if(fmt === undefined)
         throw Error("Invalid iCalendar datatype: "+type);
 
-    return fmt.parse ? fmt.parse(value, parameters || {}, calendar) : value;
+    // Handle wrong value type
+    parameters = parameters || {};
+    var otherFmt = parameters.VALUE && _types[parameters.VALUE];
+    if (otherFmt) fmt = otherFmt;
+    return fmt.parse ? fmt.parse(value, parameters, calendar) : value;
 }

--- a/spec/parser-spec.js
+++ b/spec/parser-spec.js
@@ -235,5 +235,22 @@ describe("iCalendar.parse", function() {
         assert.equal('Something;:, here',
             vevent.getProperty('X-TEST').getParameter('TESTPARAM'));
     });
+
+    it('parses DateTime Trigger correctly', function () {
+        var cal = parse_calendar(
+            'BEGIN:VCALENDAR\r\n'+
+            'PRODID:-//Bobs Software Emporium//NONSGML Bobs Calendar//EN\r\n'+
+            'VERSION:2.0\r\n'+
+            'BEGIN:VEVENT\r\n'+
+            'DTSTAMP:20111202T165900\r\n'+
+            'TRIGGER;VALUE=DATE-TIME:20111109T173216\r\n'+
+            'UID:testuid@someotherplace.com\r\n'+
+            'END:VEVENT\r\n'+
+            'END:VCALENDAR\r\n');
+
+        var vevent = cal.getComponents('VEVENT')[0];
+        expect(new Date(2011,10,9,17,32,16)).toEqual(vevent.getPropertyValue('TRIGGER'));
+
+    });
 });
 


### PR DESCRIPTION
This fixes a bug where the trigger was set to a date-time instead of a duration and would not be parsed correctly.
