### PR TITLE
Error and newline fixes

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -33,14 +33,10 @@ var iCalendar = require('./icalendar').iCalendar;
 var parse_value = types.parse_value;
 var format_value = types.format_value;
 
-
-
-var ParseError = exports.ParseError = function() {
-    Error.apply(this, arguments);
-}
-util.inherits(ParseError, Error);
-
-
+var ParseError = exports.ParseError = function(message) {
+    this.message = message;
+};
+ParseError.prototype = new Error();
 
 function expect(expect_element, expect_value, next_state) {
     // Return a function that expects a certain element and value

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -178,6 +178,11 @@ function parse_record(rec) {
 // The second argument is an optional calendar object containing VTIMEZONE
 // data to aid in the correct conversion of dates
 exports.parse_calendar = function(data, timezone) {
+    if (data.lastIndexOf('\n') !== data.length-1) {
+        // data doesn't have a terminating newline
+        data += '\n'
+    }
+    
     data = data.split(/\r?\n/);
     var calendar = new iCalendar(true);
     if(timezone) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -226,7 +226,7 @@ var format_value = exports.format_value = function(type, value, parameters) {
 
     var fmt = _types[type || 'TEXT'];
     if(fmt === undefined)
-        throw Error("Invalid iCalendar datatype: "+type);
+        throw new Error("Invalid iCalendar datatype: "+type);
 
     // PERIOD is a corner case here; it's an array of two values
     if(Array.isArray(value) && type !== 'PERIOD'
@@ -242,7 +242,7 @@ var parse_value = exports.parse_value = function(type, value, parameters, calend
 
     var fmt = _types[type || 'TEXT'];
     if(fmt === undefined)
-        throw Error("Invalid iCalendar datatype: "+type);
+        throw new Error("Invalid iCalendar datatype: "+type);
 
     // Handle wrong value type
     parameters = parameters || {};

--- a/spec/parser-spec.js
+++ b/spec/parser-spec.js
@@ -31,6 +31,17 @@ describe("iCalendar.parse", function() {
                 vevent.getPropertyValue('DTSTAMP').valueOf());
     });
 
+    it("parses data without trailing newline", function() {
+        var cal = parse_calendar(
+            'BEGIN:VCALENDAR\r\n'+
+            'PRODID:-//Bobs Software Emporium//NONSGML Bobs Calendar//EN\r\n'+
+            'VERSION:2.0\r\n'+
+            'END:VCALENDAR');
+
+        assert.equal('-//Bobs Software Emporium//NONSGML Bobs Calendar//EN',
+                    cal.getPropertyValue('PRODID'));
+    });
+
     it("decodes escaped chars as per RFC", function() {
         var cal = parse_calendar(
             'BEGIN:VCALENDAR\r\n'+


### PR DESCRIPTION
Hey,

So I started using this library but hit an issue immediately, whereby parsing my calendar would just go boom with a generic `[Error]` message and nothing else. I investigated and found the `ParseError` error type wasn't inheriting properly, so it was throwing away the stack trace and error message. The fix for this is b97956c.

Once I got to the bottom of that, I found that the real error was that the parser was failing to find the terminating `END:VCALENDAR` despite it being present in the file. After some digging I noticed there wasn't a trailing newline on the calendar I was parsing, and the `data.split(/\r?\n/);` line was truncating the last line. 90e31c8 includes a fix for files without a trailing newline.

Thanks!