### PR TITLE
CalendarObject as a Readable stream

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -24,7 +24,7 @@ var format_value = require('./types').format_value;
 
 var schema = exports.schema = { };
 
-var Readable = require('stream').Readable;
+var Readable = require('readable-stream').Readable;
 var util = require('util');
 
 var properties = exports.properties = {

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,15 +1,15 @@
 // Copyright (C) 2011 Tri Tech Computers Ltd.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -17,12 +17,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-// 
+//
 //
 
 var format_value = require('./types').format_value;
 
 var schema = exports.schema = { };
+
+var Readable = require('stream').Readable;
+var util = require('util');
 
 var properties = exports.properties = {
     // Calendar properties
@@ -98,11 +101,14 @@ var MAX_LINE = 75;
 
 
 var CalendarObject = exports.CalendarObject = function(calendar, element) {
+    Readable.call(this, { encoding: 'utf8' });
     this.calendar = calendar;
     this.element = element;
     this.components = {};
     this.properties = {};
 }
+
+util.inherits(CalendarObject, Readable);
 
 // Create an element of the correct type
 CalendarObject.create = function(element, calendar) {
@@ -158,7 +164,7 @@ CalendarObject.prototype.addComponent = function(comp) {
     }
 
     // Create a copy of the component if it's from a different
-    // calendar object to prevent changes from one place happening 
+    // calendar object to prevent changes from one place happening
     // somewhere else as well
     if(comp.calendar && comp.calendar !== this.calendar)
         comp = comp.clone();
@@ -231,6 +237,34 @@ CalendarObject.prototype.toString = function() {
 
     output.push(''); // <-- Add empty element to ensure trailing CRLF
     return output.join('\r\n');
+}
+
+CalendarObject.prototype._read = function(n) {
+    // because this method doesn't check that this.element is a 'VCALENDAR'
+    // as the toString method does only the 'VCALENDAR' is an accurate stream
+    // other objects and events are not
+    var stream = this;
+    stream.push('BEGIN:'+this.element + '\r\n');
+
+    for(var i in this.properties) {
+        this.properties[i].forEach(function(prop) {
+            prop.format().forEach(function (format) {
+                stream.push(format + '\r\n');
+            });
+        });
+    }
+
+    for(var comp in this.components) {
+        var comp = this.components[comp];
+        for(var i=0; i < comp.length; ++i) {
+            comp[i].format().forEach(function (format) {
+                stream.push(format + '\r\n');
+            });
+        }
+    }
+
+    stream.push('END:'+this.element + '\r\n');
+    stream.push(null);
 }
 
 CalendarObject.prototype.format = function() {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "type": "git",
     "url": "git://github.com/tritech/node-icalendar.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "readable-stream": "~1.1.0"
+  },
   "engines": {
     "node": ">= 0.10"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "engines": {
-    "node": "*"
+    "node": ">= 0.10"
   },
   "scripts": {
     "test": "jasmine-node spec"

--- a/spec/icalendar-spec.js
+++ b/spec/icalendar-spec.js
@@ -19,7 +19,7 @@ describe("iCalendar", function() {
     });
 
     it('calendar stream', function(done) {
-        var Writable = require('stream').Writable;
+        var Writable = require('readable-stream').Writable;
         // fake Writable stream to collect the data into a string
         function toStr(next) {
           var stream = new Writable();

--- a/spec/icalendar-spec.js
+++ b/spec/icalendar-spec.js
@@ -18,6 +18,31 @@ describe("iCalendar", function() {
             'END:VCALENDAR'], ics.format());
     });
 
+    it('calendar stream', function(done) {
+        var Writable = require('stream').Writable;
+        // fake Writable stream to collect the data into a string
+        function toStr(next) {
+          var stream = new Writable();
+          var str = "";
+          stream.write = function(chunk) {
+              str += (chunk);
+          };
+          stream.end = function() {
+              next(str);
+          };
+          return stream;
+        }
+        var ical = new icalendar.iCalendar();
+        var vevent = new icalendar.VEvent('testuid@example.com');
+        vevent.addProperty('DTSTART', new Date(Date.UTC(2011,10,12,14,0,0)));
+        vevent.addProperty('DTEND', new Date(Date.UTC(2011,10,12,15,3,0)));
+        ical.addComponent(vevent);
+        ical.pipe(toStr(function (str) {
+            assert.equal(str, ical.toString());
+            done();
+        }));
+    });
+
     it('format vevent', function() {
         var vevent = new icalendar.VEvent('testuid@daybilling.com');
         vevent.addProperty('DTSTART', new Date(Date.UTC(2011,10,12,14,00,00)));


### PR DESCRIPTION
This PR addresses tritech/node-icalendar/issues/29 see that issue for
the reasoning.

Here are some notes from implementing.

It wasn’t in my scope to allow the events themselves to be streams as
well.  Currently only the calendar object is streamable, however as you
can see in the tests you can add events to that object and the whole is
correctly streamed.

So for example this is currently not possible:

```javascript
var vevent = new icalendar.VEvent('testuid@example.com');
vevent.stream(s3.uploadStream('ical', 'uid.ics’));
```

Yet you can easily create a calendar, add the event to that calendar
and stream as expected above.

*Apologies for the white space fixes, atom likes to do that and I can't help myself.  I wouldn't mind making a complete jshint pass over the files at some point as well.*