### PR TITLE
parse_calendar to parseCalendar

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ exports.format_value = require('./types').format_value;
 exports.parse_value = require('./types').parse_value;
 exports.RRule = require('./rrule').RRule;
 
-exports.parse_calendar = require('./parser').parse_calendar;
+exports.parseCalendar = require('./parser').parseCalendar;
 exports.ParseError = require('./parser').ParseError;
 
 exports.CalendarObject = require('./base').CalendarObject;


### PR DESCRIPTION
To conform to JSHint (http://jshint.com/docs/options/#camelcase)[camel case]. Even this JSHint options will be deprecated soon, I think it is a good idea to use underscores only for uppercase variables.