### PR TITLE
Add BYHOUR, BYMINUTE and BYSECOND to support LotusNotes ICS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Several portions of the iCalendar spec remain unimplemented:
     * HOURLY, MINUTELY, and SECONDLY recurrence are not implemented.
         - Support for these is not currently planned, as they do not
           seem to be found in actual use.
-    * BYHOUR, BYMINUTE, and BYSECOND modifiers are not implement as above.
     * BYSETPOS
     * WKST
         - This could very likely become important

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -29,7 +29,7 @@
 
 var types = require('./types');
 
-var SUPPORTED_PARTS = ['FREQ','INTERVAL','COUNT','UNTIL','BYDAY','BYMONTH','BYMONTHDAY'];
+var SUPPORTED_PARTS = ['FREQ','INTERVAL','COUNT','UNTIL','BYDAY','BYMONTH', 'BYHOUR', 'BYMINUTE', 'BYSECOND', 'BYMONTHDAY'];
 var WKDAYS = ['SU','MO','TU','WE','TH','FR','SA'];
 
 function to_utc_date(dt) {
@@ -288,6 +288,42 @@ var RULE_PARTS = {
             return v.map(function(day) {
                 return (day[0] || '')+WKDAYS[day[1]];
             }).join(',');
+        }
+    },
+    BYHOUR: {
+        parse: function(v) {
+            if(typeof v === 'number') return [v];
+
+            return v.split(',').map(function(mi) {
+                return parseInt(mi,10);
+            });
+        },
+        format: function(v) {
+            return v.join(',');
+        }
+    },
+    BYMINUTE: {
+        parse: function(v) {
+            if(typeof v === 'number') return [v];
+
+            return v.split(',').map(function(mi) {
+                return parseInt(mi,10);
+            });
+        },
+        format: function(v) {
+            return v.join(',');
+        }
+    },
+    BYSECOND: {
+        parse: function(v) {
+            if(typeof v === 'number') return [v];
+
+            return v.split(',').map(function(sec) {
+                return parseInt(sec,10);
+            });
+        },
+        format: function(v) {
+            return v.join(',');
         }
     },
     EXDATE: {

--- a/spec/rrule-spec.js
+++ b/spec/rrule-spec.js
@@ -16,6 +16,8 @@ describe("RRule", function() {
             .toEqual({FREQ: 'YEARLY', BYDAY: [[-1,0]]});
         expect(new RRule('FREQ=WEEKLY;BYMONTH=1,2,3').valueOf())
             .toEqual({FREQ: 'WEEKLY', BYMONTH: [1,2,3]});
+        expect(new RRule('FREQ=YEARLY;BYMONTH=11;BYDAY=1SU;BYHOUR=2;BYMINUTE=4;BYSECOND=6').valueOf())
+            .toEqual({FREQ: 'YEARLY', BYMONTH: [11], BYDAY: [[1,0]], BYHOUR: [2], BYMINUTE: [4], BYSECOND: [6]})
         rrule = new RRule('FREQ=WEEKLY;BYMONTH=1,2,3').valueOf();
         expect(rrule.FREQ).toEqual('WEEKLY');
         expect(rrule.BYMONTH).toEqual([1,2,3]);


### PR DESCRIPTION
Add BYHOUR, BYMINUTE and BYSECOND support asked for in Issue #38 