### PR TITLE
Added full day support

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -61,12 +61,23 @@ VEvent.prototype.setDescription = function(desc) {
     this.addProperty('DESCRIPTION', desc);
 }
 
-VEvent.prototype.setDate = function(start, end) {
-    this.addProperty('DTSTART', start);
-    if(end instanceof Date)
-        this.addProperty('DTEND', end);
-    else
+VEvent.prototype.setDate = function(start, end, fullday) {
+    var startProperty = this.addProperty('DTSTART', start);
+    if (fullday) {
+      startProperty.setParameter('VALUE', 'DATE');
+      startProperty.type = 'DATE';
+    }
+
+    if(end instanceof Date) {
+        var endProperty = this.addProperty('DTEND', end);
+        if (fullday) {
+          endProperty.setParameter('VALUE', 'DATE');
+          endProperty.type = 'DATE';
+        }
+    }
+    else {
         this.addProperty('DURATION', end);
+    }
 }
 
 VEvent.prototype.rrule = function() {

--- a/spec/icalendar-spec.js
+++ b/spec/icalendar-spec.js
@@ -78,6 +78,27 @@ describe("iCalendar", function() {
             'END:VCALENDAR\r\n', vevent.toString());
     });
 
+    it('Outputs full day VEvents correctly if setDate is used', function() {
+      // VEvent objects need to get a calendar wrapper...
+      var vevent = new icalendar.VEvent('testuid@daybilling.com');
+      vevent.setDate(new Date(Date.UTC(2011,10,12,00,00,00)),
+          new Date(Date.UTC(2011,10,13,00,00,00)), true);
+
+      var dtstamp = icalendar.format_value('DATE-TIME', vevent.getPropertyValue('DTSTAMP'));
+
+      assert.equal(
+          'BEGIN:VCALENDAR\r\n'+
+          'VERSION:2.0\r\n'+
+          'PRODID:'+icalendar.PRODID+'\r\n'+
+          'BEGIN:VEVENT\r\n'+
+          'DTSTAMP:'+dtstamp+'\r\n'+
+          'UID:testuid@daybilling.com\r\n'+
+          'DTSTART;VALUE=DATE:2011 11 12\r\n'+
+          'DTEND;VALUE=DATE:2011 11 13\r\n'+
+          'END:VEVENT\r\n'+
+          'END:VCALENDAR\r\n', vevent.toString());
+    });
+
     it('wraps long lines correctly', function() {
         var vevent = new icalendar.VEvent('testuid@daybilling.com');
         vevent.setDate(new Date(Date.UTC(2011,11,2,16,59,00)), 3600);

--- a/spec/icalendar-spec.js
+++ b/spec/icalendar-spec.js
@@ -93,8 +93,8 @@ describe("iCalendar", function() {
           'BEGIN:VEVENT\r\n'+
           'DTSTAMP:'+dtstamp+'\r\n'+
           'UID:testuid@daybilling.com\r\n'+
-          'DTSTART;VALUE=DATE:2011 11 12\r\n'+
-          'DTEND;VALUE=DATE:2011 11 13\r\n'+
+          'DTSTART;VALUE=DATE:20111112\r\n'+
+          'DTEND;VALUE=DATE:20111113\r\n'+
           'END:VEVENT\r\n'+
           'END:VCALENDAR\r\n', vevent.toString());
     });


### PR DESCRIPTION
I added a change to the code for supporting full day events using the setDate() method, if noting or false is given to the last parameter it will function in the old way, this won't effect old code.
I tested the unittestes and added 1 for testing full day events.

When using toString() it outputs the dates in the following format:

```
DTSTART;VALUE=DATE:20160311
DTEND;VALUE=DATE:20160312
```
