### PR TITLE
bump version to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icalendar",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "James Emerton <james@tri-tech.com>",
   "description": "RFC5545 iCalendar parser/generator",
   "keywords": [


### PR DESCRIPTION
Hi, my team submitted a PR to add support for icalendars from LotusNotes that was already committed: https://github.com/tritech/node-icalendar/pull/40. However, we would like to use SEMVER rather than the git commit hash to pull in the update. I think this would also be confusing to other npm users, as the update hasn't been published.